### PR TITLE
update compile options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,6 @@ jobs:
           - {os: windows-latest, compiler: gcc, version: 13, shell: pwsh, release: no}
           # test intel-classic
           - {os: ubuntu-22.04, compiler: intel-classic, version: 2021.7, shell: bash, release: no}
-          # test previous gcc
-          - {os: ubuntu-latest, compiler: gcc, version: 12, shell: bash, release: no}
-          - {os: ubuntu-latest, compiler: gcc, version: 11, shell: bash, release: no}
           # test ifx
           - {os: ubuntu-22.04, compiler: intel, version: "2025.0", shell: bash, release: yes}
           - {os: windows-2022, compiler: intel, version: "2025.0", shell: pwsh, release: yes}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,18 @@ env:
   PROGRAM_NAME: triangle
 jobs:
   build:
-    name: Build and Test on ${{ matrix.os }} with ${{ matrix.compiler }} ${{ matrix.version }}
+    name: ${{ matrix.os }} ${{ matrix.compiler }} ${{ matrix.version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          # test latest gcc
-          - {os: ubuntu-latest, compiler: gcc, version: 13, shell: bash, release: no}
+          # gcc
+          - {os: ubuntu-22.04, compiler: gcc, version: 13, shell: bash, release: no}
           - {os: macos-14, compiler: gcc, version: 13, shell: bash, release: yes}
-          - {os: macos-15-intel, compiler: gcc, version: 13, shell: bash, release: yes}
-          - {os: windows-latest, compiler: gcc, version: 13, shell: pwsh, release: no}
-          # test intel-classic
+          - {os: windows-2022, compiler: gcc, version: 13, shell: pwsh, release: no}
+          # intel
           - {os: ubuntu-22.04, compiler: intel-classic, version: 2021.7, shell: bash, release: no}
-          # test ifx
           - {os: ubuntu-22.04, compiler: intel, version: "2025.0", shell: bash, release: yes}
           - {os: windows-2022, compiler: intel, version: "2025.0", shell: pwsh, release: yes}
     defaults:

--- a/meson.build
+++ b/meson.build
@@ -22,12 +22,12 @@ if cc_id == 'gcc'
 endif
 
 if cc_id == 'intel'
-  compile_args += ['-diag-disable=10441', '-fp-model=precise']
+  compile_args += ['-diag-disable=10441', '-fp-model=strict']
   link_args += ['-diag-disable=10441']
 endif
 
 if cc_id == 'intel-llvm'
-  compile_args += ['-fp-model=precise']
+  compile_args += ['-fp-model=strict']
 endif
 
 system = build_machine.system()

--- a/meson.build
+++ b/meson.build
@@ -17,12 +17,17 @@ compile_args = []
 link_args = []
 
 if cc_id == 'gcc'
+  compile_args += ['-fexcess-precision=standard', '-ffp-contract=off']
   link_args += ['-lm']
 endif
 
 if cc_id == 'intel'
-  compile_args += ['-diag-disable=10441']
+  compile_args += ['-diag-disable=10441', '-fp-model=precise']
   link_args += ['-diag-disable=10441']
+endif
+
+if cc_id == 'intel-llvm'
+  compile_args += ['-fp-model=precise']
 endif
 
 system = build_machine.system()

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,6 @@ project(
   default_options : [
     'b_vscrt=static_from_buildtype', # Link runtime libraries statically on Windows
     'buildtype=release',
-    'c_std=c17',
 ])
 
 cc = meson.get_compiler('c')

--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,7 @@ compile_args = []
 link_args = []
 
 if cc_id == 'gcc'
-  compile_args += ['-fexcess-precision=standard', '-ffp-contract=off']
+  compile_args += ['-std=gnu17', '-fexcess-precision=standard', '-ffp-contract=off']
   link_args += ['-lm']
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ project(
   default_options : [
     'b_vscrt=static_from_buildtype', # Link runtime libraries statically on Windows
     'buildtype=release',
+    'c_std=c17',
 ])
 
 cc = meson.get_compiler('c')
@@ -17,7 +18,7 @@ compile_args = []
 link_args = []
 
 if cc_id == 'gcc'
-  compile_args += ['-std=gnu17', '-fexcess-precision=standard', '-ffp-contract=off']
+  compile_args += ['-fexcess-precision=standard', '-ffp-contract=off']
   link_args += ['-lm']
 endif
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "triangle"
 channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "linux-aarch64", "osx-arm64", "osx-64"]

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,7 +3,11 @@ exe = executable(
                  meson.project_name(),
                  'triangle.c',
                  link_language : 'c',
-                 override_options: ['optimization=1'],
+                 c_args: cc.get_supported_arguments([
+                   '-ffp-contract=off',
+                   '-fno-tree-vectorize',
+                 ]),
+                 override_options: ['optimization=2'],
                  install: true
                 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,6 @@ exe = executable(
                  'triangle.c',
                  link_language : 'c',
                  install: true,
-                 override_options: cc_id == 'gcc' ? ['c_std=gnu17'] : []
+                 override_options: cc_id == 'gcc' ? ['c_std=gnu17', 'optimization=1'] : ['optimization=1']
                 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,6 @@ exe = executable(
                  'triangle.c',
                  link_language : 'c',
                  install: true,
-                 override_options: cc_id == 'gcc' ? ['c_std=c17'] : []
+                 override_options: cc_id == 'gcc' ? ['c_std=gnu17'] : []
                 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,8 +1,9 @@
 
 exe = executable(
-                 meson.project_name(), 
-                 'triangle.c', 
-                 link_language : 'c',  
-                 install: true
+                 meson.project_name(),
+                 'triangle.c',
+                 link_language : 'c',
+                 install: true,
+                 override_options: cc_id == 'gcc' ? ['c_std=c17'] : []
                 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,13 +1,8 @@
 
 exe = executable(
-                 meson.project_name(),
-                 'triangle.c',
-                 link_language : 'c',
-                 c_args: cc.get_supported_arguments([
-                   '-ffp-contract=off',
-                   '-fno-tree-vectorize',
-                 ]),
-                 override_options: ['optimization=2'],
+                 meson.project_name(), 
+                 'triangle.c', 
+                 link_language : 'c',  
                  install: true
                 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,8 +1,9 @@
 
 exe = executable(
-                 meson.project_name(), 
-                 'triangle.c', 
-                 link_language : 'c',  
+                 meson.project_name(),
+                 'triangle.c',
+                 link_language : 'c',
+                 override_options: ['optimization=1'],
                  install: true
                 )
 


### PR DESCRIPTION
* drop Intel Mac build
* fix "project" -> "workspace" in pixi.toml
* pin specific versions of runner images (oldest available for build compatibility)
* grids produced by triangle may be slightly different depending which compiler is used, add some options to make results as consistent as possible across platforms and compilers