### PR TITLE
define inexact volatile on ARM

### DIFF
--- a/src/triangle.c
+++ b/src/triangle.c
@@ -269,8 +269,11 @@
 /* #define CPU86 */
 /* #define LINUX */
 
+#if defined(__aarch64__) || defined(__arm__)
+#define INEXACT volatile
+#else
 #define INEXACT /* Nothing */
-/* #define INEXACT volatile */
+#endif
 
 /* Maximum number of characters in a file name (including the null).         */
 


### PR DESCRIPTION
Fix #13. Adds a performance hit but seems to be necessary. I think gcc on ARM is doing fused multiply-add (FMA) ops that it doesn't do on Intel.